### PR TITLE
make menu title and window controls show up on linux ui

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const cursorColor = '#abc8ff';
 const foregroundColor = '#453d40';
 const backgroundColor = '#ffffff';
-const tabBorderColor = '#E2E4E7';
+const borderColor = '#E2E4E7';
 const colors = {
   black: '#abc8ff',
   lightBlack: '#a1a2fb',
@@ -25,6 +25,7 @@ exports.decorateConfig = config => {
   return Object.assign({}, config, {
     foregroundColor,
     backgroundColor,
+    borderColor,
     cursorColor,
     colors,
     css: `
@@ -41,7 +42,7 @@ exports.decorateConfig = config => {
         right: 0;
         color: ${foregroundColor} !important;
         background: ${backgroundColor} !important;
-        border-bottom: 1px solid ${tabBorderColor} !important;
+        border-bottom: 1px solid ${borderColor} !important;
       }
       .header_shape {
         color: ${foregroundColor} !important;
@@ -53,6 +54,25 @@ exports.decorateConfig = config => {
       .tab_tab {
         border: 0;
         background-color: ${backgroundColor};
+        border-left: 1px solid ${borderColor} !important;
+	border-bottom: 1px solid ${borderColor} !important;
+      }
+      .tab_text {
+        color: ${foregroundColor};
+        font-weight: normal;
+      }
+      .tab_textActive {
+        color: ${foregroundColor};
+        font-weight: 600;
+        background-color: ${backgroundColor};
+      }
+      .tab_icon {
+        color: ${foregroundColor};
+        font-weight: 600;
+      }
+      .tab_icon:hover {
+        color: ${foregroundColor};
+        font-weight: 600;
       }
     `
  })

--- a/index.js
+++ b/index.js
@@ -54,8 +54,10 @@ exports.decorateConfig = config => {
       .tab_tab {
         border: 0;
         background-color: ${backgroundColor};
-        border-left: 1px solid ${borderColor} !important;
 	border-bottom: 1px solid ${borderColor} !important;
+      }
+      .tab_tab:not(:first-child) {
+        border-left: 1px solid ${borderColor} !important;
       }
       .tab_text {
         color: ${foregroundColor};

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const cursorColor = '#abc8ff';
 const foregroundColor = '#453d40';
 const backgroundColor = '#ffffff';
+const tabBorderColor = '#E2E4E7';
 const colors = {
   black: '#abc8ff',
   lightBlack: '#a1a2fb',
@@ -25,7 +26,35 @@ exports.decorateConfig = config => {
     foregroundColor,
     backgroundColor,
     cursorColor,
-    colors
+    colors,
+    css: `
+      ${config.css || ''}
+      .hyper_main {
+        border: none !important;
+      }
+      .splitpane_divider {
+        background-color: ${foregroundColor} !important;
+      }
+      .header_header, .header_windowHeader {
+        top: 0;
+        left: 0;
+        right: 0;
+        color: ${foregroundColor} !important;
+        background: ${backgroundColor} !important;
+        border-bottom: 1px solid ${tabBorderColor} !important;
+      }
+      .header_shape {
+        color: ${foregroundColor} !important;
+      }
+      .tabs_title {
+        color: ${foregroundColor};
+        font-weight: 600;
+      }
+      .tab_tab {
+        border: 0;
+        background-color: ${backgroundColor};
+      }
+    `
  })
 };
 


### PR DESCRIPTION
Hi, I noticed on linux that the window navigation (hamburger menu, title and tab borders) were invisible after installing this theme. I think it's a general issue with light themes in Hyper. I found some CSS from another light theme (ayu-light) and hacked in into make the UI show up. Thanks for making this cool theme!

![screenshot_20180828_170140](https://user-images.githubusercontent.com/39759/44757474-2b44e180-aae4-11e8-98d0-4cef6b8f2c4e.png)
